### PR TITLE
feat: 이벤트 도메인 모델 추가

### DIFF
--- a/booker-server/src/main/java/com/bookerapp/core/domain/model/entity/BaseEntity.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/model/entity/BaseEntity.java
@@ -2,7 +2,9 @@ package com.bookerapp.core.domain.model.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -13,6 +15,10 @@ import java.time.LocalDateTime;
 @Getter
 public abstract class BaseEntity {
 
+    @Version
+    @Column(name = "version", nullable = false)
+    private Long version = 0L;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -21,22 +27,16 @@ public abstract class BaseEntity {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    @Column(length = 50)
+    @CreatedBy
+    @Column(name = "created_by", length = 100, updatable = false)
     private String createdBy;
 
-    @Column(length = 50)
+    @LastModifiedBy
+    @Column(name = "updated_by", length = 100)
     private String updatedBy;
 
-    @Column(nullable = false)
-    private boolean isDeleted;
-
-    public void setCreatedBy(String createdBy) {
-        this.createdBy = createdBy;
-    }
-
-    public void setUpdatedBy(String updatedBy) {
-        this.updatedBy = updatedBy;
-    }
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
 
     public void markAsDeleted() {
         this.isDeleted = true;
@@ -45,8 +45,4 @@ public abstract class BaseEntity {
     public void unmarkAsDeleted() {
         this.isDeleted = false;
     }
-<<<<<<<< HEAD:booker-server/src/main/java/com/bookerapp/core/domain/model/BaseEntity.java
 }
-========
-} 
->>>>>>>> b0cca449fc1eedbe7245826d588fe47133680064:booker-server/src/main/java/com/bookerapp/core/domain/model/entity/BaseEntity.java

--- a/booker-server/src/main/java/com/bookerapp/core/domain/model/enums/BookStatus.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/model/enums/BookStatus.java
@@ -1,0 +1,9 @@
+package com.bookerapp.core.domain.model.enums;
+
+public enum BookStatus {
+    AVAILABLE,    // 대출 가능
+    LOANED,      // 대출 중
+    RESERVED,    // 예약됨
+    PROCESSING,  // 처리 중 (입고/등록 등)
+    UNAVAILABLE  // 대출 불가 (분실/파손 등)
+}

--- a/booker-server/src/main/java/com/bookerapp/core/domain/model/enums/Floor.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/model/enums/Floor.java
@@ -1,0 +1,27 @@
+package com.bookerapp.core.domain.model.enums;
+
+import com.bookerapp.core.domain.exception.InvalidFloorException;
+
+public enum Floor {
+    FOURTH(4),
+    TWELFTH(12);
+
+    private final int value;
+
+    Floor(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static Floor fromValue(int value) {
+        for (Floor floor : Floor.values()) {
+            if (floor.value == value) {
+                return floor;
+            }
+        }
+        throw new InvalidFloorException(value);
+    }
+}

--- a/booker-server/src/main/java/com/bookerapp/core/domain/model/enums/LoanStatus.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/model/enums/LoanStatus.java
@@ -1,0 +1,10 @@
+package com.bookerapp.core.domain.model.enums;
+
+public enum LoanStatus {
+    PENDING,     // 대출 신청됨
+    WAITING,     // 대기 리스트에 있음
+    ACTIVE,      // 대출 중
+    OVERDUE,     // 연체
+    RETURNED,    // 반납 완료
+    CANCELLED    // 취소됨
+}

--- a/booker-server/src/main/java/com/bookerapp/core/domain/model/event/Event.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/model/event/Event.java
@@ -1,0 +1,131 @@
+package com.bookerapp.core.domain.model.event;
+
+import com.bookerapp.core.domain.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EventType type;
+
+    @Column(nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false)
+    private LocalDateTime endTime;
+
+    @Column(nullable = false)
+    private int maxParticipants;
+
+
+    @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    private Member presenter;
+
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    private List<EventParticipation> participants = new ArrayList<>();
+
+    public Event(String title, String description, EventType type, LocalDateTime startTime,
+                LocalDateTime endTime, int maxParticipants, Member presenter) {
+        this.title = title;
+        this.description = description;
+        this.type = type;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.maxParticipants = maxParticipants;
+        this.presenter = presenter;
+    }
+
+    public void addParticipant(Member member) {
+        if (isFullyBooked()) {
+            int nextWaitingNumber = getNextWaitingNumber();
+            EventParticipation participation = new EventParticipation(this, member, ParticipationStatus.WAITING, nextWaitingNumber);
+            participants.add(participation);
+            return;
+        }
+
+        EventParticipation participation = new EventParticipation(this, member, ParticipationStatus.CONFIRMED);
+        participants.add(participation);
+    }
+
+    public void removeParticipant(Member member) {
+        participants.removeIf(p -> p.getParticipant().equals(member));
+        promoteFromWaitingList();
+    }
+
+    public void updateSchedule(LocalDateTime startTime, LocalDateTime endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public void cancelEvent() {
+        participants.forEach(EventParticipation::cancelParticipation);
+        participants.clear();
+    }
+
+    public boolean isFullyBooked() {
+        return getConfirmedParticipants().size() >= maxParticipants;
+    }
+
+    public void promoteFromWaitingList() {
+        if (isFullyBooked()) {
+            return;
+        }
+
+        List<EventParticipation> waitingParticipants = getWaitingParticipants();
+        if (!waitingParticipants.isEmpty()) {
+            EventParticipation nextParticipation = waitingParticipants.get(0);
+            nextParticipation.promoteToParticipant();
+            reorderWaitingList();
+        }
+    }
+
+    private List<EventParticipation> getConfirmedParticipants() {
+        return participants.stream()
+                .filter(p -> p.getStatus() == ParticipationStatus.CONFIRMED)
+                .toList();
+    }
+
+    private List<EventParticipation> getWaitingParticipants() {
+        return participants.stream()
+                .filter(p -> p.getStatus() == ParticipationStatus.WAITING)
+                .sorted(Comparator.comparing(EventParticipation::getWaitingNumber))
+                .toList();
+    }
+
+    private int getNextWaitingNumber() {
+        return participants.stream()
+                .filter(p -> p.getStatus() == ParticipationStatus.WAITING)
+                .map(EventParticipation::getWaitingNumber)
+                .max(Integer::compareTo)
+                .orElse(0) + 1;
+    }
+
+    private void reorderWaitingList() {
+        List<EventParticipation> waitingParticipants = getWaitingParticipants();
+        for (int i = 0; i < waitingParticipants.size(); i++) {
+            waitingParticipants.get(i).updateWaitingNumber(i + 1);
+        }
+    }
+}

--- a/booker-server/src/main/java/com/bookerapp/core/domain/model/event/EventParticipation.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/model/event/EventParticipation.java
@@ -1,0 +1,71 @@
+package com.bookerapp.core.domain.model.event;
+
+import com.bookerapp.core.domain.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventParticipation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    private Member participant;
+
+    @Enumerated(EnumType.STRING)
+    private ParticipationStatus status;
+
+    private LocalDateTime registrationDate;
+
+    private Integer waitingNumber;
+
+    public EventParticipation(Event event, Member participant, ParticipationStatus status) {
+        this(event, participant, status, null);
+    }
+
+    public EventParticipation(Event event, Member participant, ParticipationStatus status, Integer waitingNumber) {
+        this.event = event;
+        this.participant = participant;
+        this.status = status;
+        this.registrationDate = LocalDateTime.now();
+        this.waitingNumber = waitingNumber;
+    }
+
+    public void changeStatus(ParticipationStatus newStatus) {
+        this.status = newStatus;
+        notifyStatusChange();
+    }
+
+    public void cancelParticipation() {
+        this.status = ParticipationStatus.CANCELLED;
+        this.waitingNumber = null;
+        notifyStatusChange();
+    }
+
+    public void promoteToParticipant() {
+        this.status = ParticipationStatus.CONFIRMED;
+        this.waitingNumber = null;
+        notifyStatusChange();
+    }
+
+    public void updateWaitingNumber(int newWaitingNumber) {
+        if (this.status == ParticipationStatus.WAITING) {
+            this.waitingNumber = newWaitingNumber;
+        }
+    }
+
+    public void notifyStatusChange() {
+        // TODO: Implement notification logic
+    }
+}

--- a/booker-server/src/main/java/com/bookerapp/core/domain/model/event/EventType.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/model/event/EventType.java
@@ -1,0 +1,19 @@
+package com.bookerapp.core.domain.model.event;
+
+public enum EventType {
+    TECH_TALK("기술 세미나"),
+    WORKSHOP("워크샵"),
+    STUDY_GROUP("스터디 그룹"),
+    CONFERENCE("컨퍼런스"),
+    MEETUP("밋업");
+
+    private final String description;
+
+    EventType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/booker-server/src/main/java/com/bookerapp/core/domain/model/event/Member.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/model/event/Member.java
@@ -1,0 +1,60 @@
+package com.bookerapp.core.domain.model.event;
+
+import com.bookerapp.core.domain.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "members")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String memberId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column
+    private String department;
+
+    @Column
+    private String position;
+
+    public Member(String memberId, String name, String email) {
+        this.memberId = memberId;
+        this.name = name;
+        this.email = email;
+    }
+
+    public Member(String memberId, String name, String email, String department, String position) {
+        this.memberId = memberId;
+        this.name = name;
+        this.email = email;
+        this.department = department;
+        this.position = position;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return memberId != null ? memberId.equals(member.memberId) : member.memberId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return memberId != null ? memberId.hashCode() : 0;
+    }
+}

--- a/booker-server/src/main/java/com/bookerapp/core/domain/model/event/ParticipationStatus.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/model/event/ParticipationStatus.java
@@ -1,0 +1,17 @@
+package com.bookerapp.core.domain.model.event;
+
+public enum ParticipationStatus {
+    CONFIRMED("확정"),
+    WAITING("대기"),
+    CANCELLED("취소");
+
+    private final String description;
+
+    ParticipationStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/booker-server/src/main/java/com/bookerapp/core/domain/repository/EventRepository.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/repository/EventRepository.java
@@ -1,0 +1,31 @@
+package com.bookerapp.core.domain.repository;
+
+import com.bookerapp.core.domain.model.event.Event;
+import com.bookerapp.core.domain.model.event.EventType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+    Page<Event> findByType(EventType type, Pageable pageable);
+
+    @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+    @Query("SELECT e FROM Event e WHERE e.id = :id")
+    Optional<Event> findByIdWithOptimisticLock(@Param("id") Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Event e WHERE e.id = :id")
+    Optional<Event> findByIdWithPessimisticWriteLock(@Param("id") Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Query("SELECT e FROM Event e WHERE e.id = :id")
+    Optional<Event> findByIdWithPessimisticReadLock(@Param("id") Long id);
+}

--- a/booker-server/src/main/java/com/bookerapp/core/domain/repository/MemberRepository.java
+++ b/booker-server/src/main/java/com/bookerapp/core/domain/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.bookerapp.core.domain.repository;
+
+import com.bookerapp.core.domain.model.event.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByMemberId(String memberId);
+    Optional<Member> findByEmail(String email);
+}


### PR DESCRIPTION
- Event, EventParticipation, Member 엔티티 구현
- BaseEntity에 version 필드 추가 (낙관적 락용)
- EventType, ParticipationStatus enum 추가
- EventRepository, MemberRepository 인터페이스 정의
- BookStatus, LoanStatus enum을 enums 패키지로 이동